### PR TITLE
feat: add support for custom Artifact Registry repository name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -184,8 +184,8 @@ resource "google_artifact_registry_repository" "this" {
   project  = var.google_project_id
   location = var.region
 
-  repository_id = var.name
-  description   = "${var.name} container registry"
+  repository_id = coalesce(var.gcr_registry_name, var.name)
+  description   = "${coalesce(var.gcr_registry_name, var.name)} container registry"
   format        = "DOCKER"
 
   labels = var.tags
@@ -615,9 +615,7 @@ module "observability" {
   source = "./modules/observability"
   count  = var.create_observability ? 1 : 0
 
-  name = var.name
+  name       = var.name
   project_id = var.google_project_id
-  namespace = var.datarobot_namespace
-
-  tags = var.tags
+  namespace  = var.datarobot_namespace
 }

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,12 @@ variable "create_container_registry" {
   default     = true
 }
 
+variable "gcr_registry_name" {
+  description = "Name of the Artifact Registry repository. Defaults to the name if not specified."
+  type        = string
+  default     = null
+}
+
 
 ################################################################################
 # Kubernetes


### PR DESCRIPTION
Remove tags as not supported variable in observability module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: defaults preserve current behavior, but setting `gcr_registry_name` may change the Artifact Registry `repository_id` (potentially forcing a new repo) and dropping `tags` only affects the observability module wiring.
> 
> **Overview**
> Adds `gcr_registry_name` to optionally override the created Artifact Registry `repository_id` (and description) instead of always using `var.name`.
> 
> Cleans up the `observability` module call by removing the unused/unsupported `tags` input while keeping `name`, `project_id`, and `namespace`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a72e50b00c003e85fc1f7c876c1204dfe0d03a3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->