### PR TITLE
feat(ingress-nginx): increase shutdown time to 600s

### DIFF
--- a/modules/ingress-nginx/values.yaml
+++ b/modules/ingress-nginx/values.yaml
@@ -5,7 +5,9 @@ controller:
   config:
     use-forwarded-headers: "true"
     use-proxy-protocol: "true"
+    worker-shutdown-timeout: "600s"
   replicaCount: 3
+  terminationGracePeriodSeconds: 600
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Helm values change that only affects ingress-nginx pod termination behavior, but could delay rollouts if the timeout is too long for the environment.
> 
> **Overview**
> Increases `ingress-nginx` shutdown/termination timeouts to **600s** by setting `controller.config.worker-shutdown-timeout` and `controller.terminationGracePeriodSeconds` in `modules/ingress-nginx/values.yaml`, allowing more time for in-flight connections to drain during pod termination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856c38ed313ae8580c07d212d57912fac95f5920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->