### PR TITLE
feat: enhance MongoDB, redis, postgres  and private link service modues with additional configuration options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ module "dns" {
 
   project_id                         = var.google_project_id
   type                               = var.dns_zone_public ? "public" : "private"
-  name                               = "${var.name}-dns"
+  name                               = coalesce(var.dns_zone_name, "${var.name}-dns")
   domain                             = "${var.domain_name}."
   private_visibility_config_networks = var.dns_zone_public ? [] : [local.vpc_self_link]
   force_destroy                      = var.dns_zone_force_destroy
@@ -304,7 +304,7 @@ resource "google_compute_global_address" "postgres" {
   count = var.create_postgres ? 1 : 0
 
   project       = var.google_project_id
-  name          = "${var.name}-postgres-address"
+  name          = coalesce(var.postgres_address_name, "${var.name}-postgres-address")
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   address       = split("/", local.postgres_cidr)[0]
@@ -317,13 +317,15 @@ module "postgres" {
   version = "~> 26.0"
   count   = var.create_postgres ? 1 : 0
 
-  name              = "${var.name}-postgres"
+  name              = coalesce(var.postgres_name, "${var.name}-postgres")
   project_id        = var.google_project_id
+  region            = var.region
   availability_type = var.postgres_availability_type
   ip_configuration = {
     private_network    = local.vpc_self_link
     allocated_ip_range = google_compute_global_address.postgres[0].name
     ssl_mode           = "ENCRYPTED_ONLY"
+    ipv4_enabled       = var.postgres_ipv4_enabled
   }
 
   database_version      = var.postgres_database_version
@@ -335,6 +337,8 @@ module "postgres" {
   enable_default_user = true
   user_name           = "postgres"
 
+  maintenance_window_day          = var.postgres_maintenance_window_day
+  maintenance_window_hour         = var.postgres_maintenance_window_hour
   maintenance_window_update_track = "stable"
   deletion_protection             = var.postgres_deletion_protection
   backup_configuration = {
@@ -360,7 +364,7 @@ resource "google_compute_global_address" "redis" {
   count = var.create_redis ? 1 : 0
 
   project       = var.google_project_id
-  name          = "${var.name}-redis-address"
+  name          = coalesce(var.redis_address_name, "${var.name}-redis-address")
   address_type  = "INTERNAL"
   purpose       = "VPC_PEERING"
   address       = split("/", local.redis_cidr)[0]
@@ -373,7 +377,7 @@ module "redis" {
   version = "~> 15.0"
   count   = var.create_redis ? 1 : 0
 
-  name                    = "${var.name}-redis"
+  name                    = coalesce(var.redis_name, "${var.name}-redis")
   project_id              = var.google_project_id
   region                  = var.region
   authorized_network      = local.vpc_name
@@ -383,6 +387,8 @@ module "redis" {
   auth_enabled            = true
   transit_encryption_mode = var.redis_transit_encryption_mode
   memory_size_gb          = var.redis_memory_size_gb
+  display_name            = var.redis_display_name
+  maintenance_policy      = var.redis_maintenance_policy
 
   labels = var.tags
 
@@ -433,13 +439,17 @@ module "mongodb" {
   source = "./modules/mongodb"
   count  = var.create_mongodb ? 1 : 0
 
-  name                   = var.name
-  google_project_id      = var.google_project_id
-  region                 = var.region
-  vpc_name               = local.vpc_name
-  subnet                 = local.mongodb_subnet.name
-  subnet_cidr            = local.mongodb_subnet.ip_cidr_range
-  project_ip_access_list = local.kubernetes_nodes_subnet.ip_cidr_range
+  name                                         = coalesce(var.mongodb_name, var.name)
+  google_project_id                            = var.google_project_id
+  region                                       = var.region
+  vpc_name                                     = local.vpc_name
+  subnet                                       = local.mongodb_subnet.name
+  subnet_cidr                                  = local.mongodb_subnet.ip_cidr_range
+  project_ip_access_list                       = coalesce(var.mongodb_project_ip_access_list, local.kubernetes_nodes_subnet.ip_cidr_range)
+  address_name_prefix                          = var.mongodb_address_name_prefix
+  password_constraints                         = var.password_constraints
+  privatelink_delete_on_create_timeout         = var.mongodb_privatelink_delete_on_create_timeout
+  privatelink_service_delete_on_create_timeout = var.mongodb_privatelink_service_delete_on_create_timeout
 
   mongodb_version                    = var.mongodb_version
   atlas_org_id                       = var.mongodb_atlas_org_id
@@ -482,7 +492,8 @@ module "private_link_service" {
   ingress_psc_consumer_allow_list_projects = var.ingress_psc_consumer_projects
   psc_nat_subnets                          = [local.ingress_psc_subnet.name]
 
-  ingress_service_name = var.ingress_service_name
+  ingress_service_name    = var.ingress_service_name
+  service_attachment_name = var.ingress_psc_service_attachment_name
 
   depends_on = [local.gke_cluster_name, module.ingress_nginx]
 }

--- a/modules/mongodb/main.tf
+++ b/modules/mongodb/main.tf
@@ -16,8 +16,8 @@ resource "mongodbatlas_project_ip_access_list" "this" {
 resource "mongodbatlas_privatelink_endpoint" "this" {
   project_id               = mongodbatlas_project.this.id
   provider_name            = local.cloud_provider
-  region                   = local.region
-  delete_on_create_timeout = true
+  region                   = var.region
+  delete_on_create_timeout = var.privatelink_delete_on_create_timeout
   timeouts {
     create = "30m"
     delete = "30m"
@@ -29,7 +29,7 @@ resource "mongodbatlas_privatelink_endpoint" "this" {
 resource "google_compute_address" "this" {
   count        = 50
   project      = var.google_project_id
-  name         = "${var.name}-mongodb-address-${count.index}"
+  name         = "${coalesce(var.address_name_prefix, "${var.name}-mongodb-address")}-${count.index}"
   subnetwork   = var.subnet
   address_type = "INTERNAL"
   address      = cidrhost(var.subnet_cidr, count.index + var.network_reservation_ip_offset) # GCP reserves first 2 addresses in subnet
@@ -58,7 +58,7 @@ resource "mongodbatlas_privatelink_endpoint_service" "this" {
   provider_name            = local.cloud_provider
   endpoint_service_id      = var.vpc_name
   gcp_project_id           = var.google_project_id
-  delete_on_create_timeout = true
+  delete_on_create_timeout = var.privatelink_service_delete_on_create_timeout
   timeouts {
     create = "30m"
     delete = "30m"

--- a/modules/mongodb/users.tf
+++ b/modules/mongodb/users.tf
@@ -1,9 +1,11 @@
 resource "random_password" "admin" {
-  length      = 32
-  special     = false
-  min_lower   = 1
-  min_upper   = 1
-  min_numeric = 1
+  length           = var.password_constraints.length
+  min_lower        = var.password_constraints.min_lower
+  min_upper        = var.password_constraints.min_upper
+  min_numeric      = var.password_constraints.min_numeric
+  min_special      = var.password_constraints.min_special
+  special          = var.password_constraints.special
+  override_special = var.password_constraints.override_special
 }
 
 resource "mongodbatlas_database_user" "admin" {

--- a/modules/mongodb/variables.tf
+++ b/modules/mongodb/variables.tf
@@ -33,6 +33,38 @@ variable "project_ip_access_list" {
   type        = string
 }
 
+variable "privatelink_delete_on_create_timeout" {
+  description = "Whether to delete the private link endpoint on create timeout. Defaults to null (attribute omitted) to avoid ForceNew on migrated resources — Atlas API does not persist this flag."
+  type        = bool
+  default     = null
+}
+
+variable "address_name_prefix" {
+  description = "Prefix for GCP compute address and forwarding rule names. If not specified, defaults to `<name>-mongodb-address`."
+  type        = string
+  default     = null
+}
+
+variable "password_constraints" {
+  description = "Constraints to put on any generated passwords"
+  type = object({
+    length           = number
+    min_lower        = optional(number)
+    min_numeric      = optional(number)
+    min_upper        = optional(number)
+    min_special      = optional(number, 0)
+    special          = optional(bool)
+    override_special = optional(string)
+  })
+  default = {
+    length           = 32
+    min_lower        = 1
+    min_numeric      = 1
+    min_upper        = 1
+    override_special = "-"
+  }
+}
+
 variable "mongodb_version" {
   description = "MongoDB version"
   type        = string
@@ -99,4 +131,10 @@ variable "tags" {
 variable "network_reservation_ip_offset" {
   type        = number
   description = "Value to offset the network reservation IP"
+}
+
+variable "privatelink_service_delete_on_create_timeout" {
+  type        = bool
+  default     = null
+  description = "Whether to delete the privatelink endpoint service on create timeout. Defaults to null (attribute omitted) to avoid ForceNew on migrated resources — Atlas API does not persist this flag."
 }

--- a/modules/private-link-service/main.tf
+++ b/modules/private-link-service/main.tf
@@ -7,7 +7,7 @@ resource "kubectl_manifest" "internal_ingress_psc" {
     apiVersion = "networking.gke.io/v1"
     kind       = "ServiceAttachment"
     metadata = {
-      name      = "datarobot-internal-ingress-psc"
+      name      = var.service_attachment_name
       namespace = local.namespace
     }
     spec = {

--- a/modules/private-link-service/variables.tf
+++ b/modules/private-link-service/variables.tf
@@ -31,3 +31,9 @@ variable "ingress_service_name" {
   description = "The name of the ingress service to attach the private link to."
   type        = string
 }
+
+variable "service_attachment_name" {
+  description = "Name of the ServiceAttachment Kubernetes resource. If not specified, defaults to `datarobot-internal-ingress-psc`."
+  type        = string
+  default     = "datarobot-internal-ingress-psc"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,12 @@ variable "dns_zone_force_destroy" {
   default     = false
 }
 
+variable "dns_zone_name" {
+  description = "Name of the Cloud DNS managed zone to create. If not specified, defaults to `<name>-dns`."
+  type        = string
+  default     = null
+}
+
 
 ################################################################################
 # Storage
@@ -310,6 +316,18 @@ variable "create_postgres" {
   default     = false
 }
 
+variable "postgres_name" {
+  description = "Name of the CloudSQL PostgreSQL instance. If not specified, defaults to `<name>-postgres`."
+  type        = string
+  default     = null
+}
+
+variable "postgres_address_name" {
+  description = "Name of the global address reservation for PostgreSQL VPC peering. If not specified, defaults to `<name>-postgres-address`."
+  type        = string
+  default     = null
+}
+
 variable "postgres_database_version" {
   description = "The PostgreSQL version to use"
   type        = string
@@ -346,6 +364,24 @@ variable "postgres_disk_autoresize_limit" {
   default     = 0
 }
 
+variable "postgres_ipv4_enabled" {
+  description = "Whether to assign a public IPv4 address to the Cloud SQL instance. Defaults to false (private-only)."
+  type        = bool
+  default     = false
+}
+
+variable "postgres_maintenance_window_day" {
+  description = "Day of the week (1=Monday .. 7=Sunday) for the Cloud SQL maintenance window."
+  type        = number
+  default     = 1
+}
+
+variable "postgres_maintenance_window_hour" {
+  description = "Hour of the day (0-23 UTC) for the Cloud SQL maintenance window."
+  type        = number
+  default     = 23
+}
+
 variable "postgres_deletion_protection" {
   description = "Whether Terraform will be prevented from destroying the instance. When the field is set to true or unset in Terraform state, a terraform apply or terraform destroy that would delete the instance will fail. When the field is set to false, deleting the instance is allowed"
   type        = bool
@@ -370,6 +406,18 @@ variable "create_redis" {
   default     = false
 }
 
+variable "redis_name" {
+  description = "Name of the Memorystore Redis instance. If not specified, defaults to `<name>-redis`."
+  type        = string
+  default     = null
+}
+
+variable "redis_address_name" {
+  description = "Name of the global address reservation for Redis VPC peering. If not specified, defaults to `<name>-redis-address`."
+  type        = string
+  default     = null
+}
+
 variable "redis_tier" {
   description = "The service tier of the instance: BASIC or STANDARD_HA"
   type        = string
@@ -388,6 +436,26 @@ variable "redis_memory_size_gb" {
   default     = 8
 }
 
+variable "redis_display_name" {
+  description = "An arbitrary and optional user-provided name for the instance."
+  type        = string
+  default     = null
+}
+
+variable "redis_maintenance_policy" {
+  description = "Maintenance policy for the Redis instance (weekly window day and start time)."
+  type = object({
+    day = string
+    start_time = object({
+      hours   = number
+      minutes = number
+      seconds = number
+      nanos   = number
+    })
+  })
+  default = null
+}
+
 
 ################################################################################
 # MongoDB
@@ -397,6 +465,12 @@ variable "create_mongodb" {
   description = "Whether to create a MongoDB Atlas instance"
   type        = bool
   default     = false
+}
+
+variable "mongodb_name" {
+  description = "Name of the MongoDB Atlas instance. If not specified, the `name` variable will be used."
+  type        = string
+  default     = null
 }
 
 variable "existing_mongodb_subnet_name" {
@@ -487,6 +561,50 @@ variable "mongodb_network_reservation_ip_offset" {
   type        = number
   default     = 2
   description = "Value to offset the network reservation IP"
+}
+
+variable "mongodb_privatelink_delete_on_create_timeout" {
+  description = "Whether to delete the private link endpoint on create timeout. Defaults to null (attribute omitted) to avoid ForceNew on migrated resources."
+  type        = bool
+  default     = null
+}
+
+variable "mongodb_privatelink_service_delete_on_create_timeout" {
+  description = "Whether to delete the privatelink endpoint service on create timeout. Defaults to null (attribute omitted) to avoid ForceNew on migrated resources."
+  type        = bool
+  default     = null
+}
+
+variable "mongodb_address_name_prefix" {
+  description = "Prefix for GCP compute address and forwarding rule names. If not specified, defaults to `<mongodb_name>-mongodb-address`."
+  type        = string
+  default     = null
+}
+
+variable "mongodb_project_ip_access_list" {
+  description = "CIDR to add to the MongoDB Atlas project IP access list. If not specified, the Kubernetes nodes subnet CIDR is used."
+  type        = string
+  default     = null
+}
+
+variable "password_constraints" {
+  description = "Constraints to put on any generated passwords"
+  type = object({
+    length           = number
+    min_lower        = optional(number)
+    min_numeric      = optional(number)
+    min_upper        = optional(number)
+    min_special      = optional(number, 0)
+    special          = optional(bool)
+    override_special = optional(string)
+  })
+  default = {
+    length           = 32
+    min_lower        = 1
+    min_numeric      = 1
+    min_upper        = 1
+    override_special = "-"
+  }
 }
 
 ################################################################################
@@ -614,6 +732,12 @@ variable "ingress_service_name" {
   description = "The name of the ingress service to attach the private link to."
   type        = string
   default     = "ingress-nginx-controller"
+}
+
+variable "ingress_psc_service_attachment_name" {
+  description = "Name of the ServiceAttachment Kubernetes resource. If not specified, defaults to `datarobot-internal-ingress-psc`."
+  type        = string
+  default     = "datarobot-internal-ingress-psc"
 }
 
 #################################################################################


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches live data-plane resources (Postgres IPv4, maintenance windows, MongoDB passwords/privatelink) where misconfiguration could cause replace plans or connectivity changes; defaults largely preserve prior behavior.
> 
> **Overview**
> Adds optional **override variables** so DNS, Postgres, Redis, MongoDB, and ingress PSC resources can keep **stable names and settings** when adopting existing infrastructure or migrating state—defaults stay `${var.name}-…` via `coalesce`.
> 
> **Postgres** gains explicit `region`, configurable public IPv4 (`postgres_ipv4_enabled`), and maintenance window day/hour. **Redis** can set `display_name` and `maintenance_policy`. **MongoDB** wires through custom Atlas IP allowlist CIDR, GCP address name prefix, configurable admin password rules, and **nullable** `delete_on_create_timeout` on privatelink resources to avoid unwanted `ForceNew` on imports. **Ingress PSC** ServiceAttachment metadata name is configurable (`ingress_psc_service_attachment_name` / `service_attachment_name`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c570095b433bbb721cb412232058c4bc5dc33fa0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->