### PR TITLE
feat: add postgres_edition variable to configure Cloud SQL instance e…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -329,6 +329,7 @@ module "postgres" {
   }
 
   database_version      = var.postgres_database_version
+  edition               = var.postgres_edition
   tier                  = var.postgres_tier
   disk_type             = var.postgres_disk_type
   disk_size             = var.postgres_disk_size

--- a/variables.tf
+++ b/variables.tf
@@ -340,6 +340,12 @@ variable "postgres_availability_type" {
   default     = "REGIONAL"
 }
 
+variable "postgres_edition" {
+  description = "The edition of the Cloud SQL instance. Can be ENTERPRISE or ENTERPRISE_PLUS."
+  type        = string
+  default     = "ENTERPRISE"
+}
+
 variable "postgres_tier" {
   description = "The machine type to use. See tiers for more details and supported versions. Postgres supports only shared-core machine types, and custom machine types such as db-custom-2-13312."
   type        = string


### PR DESCRIPTION
Fix for 
```shell
│    413 │ Error: Error, failed to create instance gcp-staging: googleapi: Error 400: Invalid request: Invalid Tier (db-custom-4-16384) for (ENTERPRISE_PLUS) Edition. Use a predefined Tier  │
│          like db-perf-optimized-N-* instead. Learn more at https://cloud.google.com/sql/docs/postgres/create-instance#machine-types., invalid
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing edition on an existing instance can trigger Cloud SQL replacement or billing/tier constraints; default matches typical Enterprise setups but overrides need careful apply review.
> 
> **Overview**
> Adds configurable **Cloud SQL edition** for the PostgreSQL module via a new `postgres_edition` variable (default `ENTERPRISE`, documented as `ENTERPRISE` or `ENTERPRISE_PLUS`).
> 
> The `module.postgres` block now passes `edition = var.postgres_edition` so callers can opt into Enterprise Plus without forking the module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88e1bee5d2db412cd23e03759e42689432096c80. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->